### PR TITLE
StatniWeby box typo

### DIFF
--- a/Web/Views/StatniWeby/Dalsi.cshtml
+++ b/Web/Views/StatniWeby/Dalsi.cshtml
@@ -51,18 +51,7 @@
 <div class="clearfix"></div>
 @WebyChartUtil.TableNextGroups(Model.id)
 
-<div class="bs-callout primary">
-    <h4>Hlídání dostupnosti státní webů. Co to vlastně děláme?</h4>
-    <p>
-        Měříme každou minutu, zda důležité weby státu vůbec běží, a pokud ano, tak jak rychle odpovídají. A tomu odpovídají i zobrazené barvy.
-        Pokud služba odpovídá rychle, dáváme <b style="color:@(UptimeServer.Availability.GetStatusChartColor(UptimeSSL.Statuses.OK))">zelenou - v pořádku</b>.
-        Pokud odpovídá déle, dáváme <b style="color:@(UptimeServer.Availability.GetStatusChartColor(UptimeSSL.Statuses.Pomalé))">oranžovou - pomalá odpověď.</b>.
-        Pokud neodpoví nebo odpoví za dlouhou dobu, použijeme <b style="color:@(UptimeServer.Availability.GetStatusChartColor(UptimeSSL.Statuses.Nedostupné))">červenou za nedostupnost</b>.
-    </p>
-    <p>
-        <a href="@Url.Action("JakMerime", "StatniWeby")">Podrobný popis měření a hodnocení</a>.
-    </p>
-</div>
+<partial name="_CoVlastneDelamePartial.cshtml" />
 
 <p class="text-muted">Údaje na této stránce mohou být až 20 minut staré.</p>
 

--- a/Web/Views/StatniWeby/Index.cshtml
+++ b/Web/Views/StatniWeby/Index.cshtml
@@ -267,18 +267,7 @@
 @WebyChartUtil.TableNextGroups("index")
 
 
-<div class="bs-callout primary">
-    <h4>Hlídání dostupnosti státní webů. Co to vlastně děláme?</h4>
-    <p>
-        Měříme každou minutu, zda důležité weby státu vůbec běží, a pokud ano, tak jak rychle odpovídají. A tomu odpovídají i zobrazené barvy.
-        Pokud služba odpovídá rychle, dáváme <b style="color:@(UptimeServer.Availability.GetStatusChartColor(UptimeSSL.Statuses.OK))">zelenou - v pořádku</b>.
-        Pokud odpovídá déle, dáváme <b style="color:@(UptimeServer.Availability.GetStatusChartColor(UptimeSSL.Statuses.Pomalé))">oranžovou - pomalá odpověď.</b>.
-        Pokud neodpoví nebo odpoví za dlouhou dobu, použijeme <b style="color:@(UptimeServer.Availability.GetStatusChartColor(UptimeSSL.Statuses.Nedostupné))">červenou za nedostupnost</b>.
-    </p>
-    <p>
-        <a href="@Url.Action("JakMerime", "StatniWeby")">Podrobný popis měření a hodnocení</a>.
-    </p>
-</div>
+<partial name="_CoVlastneDelamePartial.cshtml" />
 
 <div class="clearfix"></div>
 <p class="text-muted">Údaje na této stránce mohou být až 5 minut staré.</p>

--- a/Web/Views/StatniWeby/Info.cshtml
+++ b/Web/Views/StatniWeby/Info.cshtml
@@ -314,21 +314,10 @@ else
 
 
 
-    <div class="bs-callout primary">
-        <h4>Hlídání dostupnosti státní webů. Co to vlastně děláme?</h4>
-        <p>
-            Měříme každou minutu, zda důležité weby státu vůbec běží, a pokud ano, tak jak rychle odpovídají. A tomu odpovídají i zobrazené barvy.
-            Pokud služba odpovídá rychle, dáváme <b style="color:@(UptimeServer.Availability.GetStatusChartColor(UptimeSSL.Statuses.OK))">zelenou - v pořádku</b>.
-            Pokud odpovídá déle, dáváme <b style="color:@(UptimeServer.Availability.GetStatusChartColor(UptimeSSL.Statuses.Pomalé))">oranžovou - pomalá odpověď.</b>.
-            Pokud neodpoví nebo odpoví za dlouhou dobu, použijeme <b style="color:@(UptimeServer.Availability.GetStatusChartColor(UptimeSSL.Statuses.Nedostupné))">červenou za nedostupnost</b>.
-        </p>
-        <p>
-            Systém hodnocení HTTPS je jednoduchý: A+ je nejlepší známka, F nejhorší, M znamená špatné jméno serveru v certifikátu, T znamená špatný certifikát, X že zabezpečený přenos není vůbec podporován.
-        </p>
-        <p>
-            <a href="@Url.Action("JakMerime", "StatniWeby")">Podrobný popis měření a hodnocení</a>.
-        </p>
-    </div>
+    @{
+        ViewData["DisplayHttpsRating"] = true;
+    }
+    <partial name="_CoVlastneDelamePartial.cshtml" view-data="ViewData" />
 
 
 

--- a/Web/Views/StatniWeby/_CoVlastneDelamePartial.cshtml
+++ b/Web/Views/StatniWeby/_CoVlastneDelamePartial.cshtml
@@ -1,0 +1,18 @@
+<div class="bs-callout primary">
+    <h4>Hlídání dostupnosti státní webů. Co to vlastně děláme?</h4>
+    <p>
+        Měříme každou minutu, zda důležité weby státu vůbec běží, a pokud ano, tak jak rychle odpovídají. A tomu odpovídají i zobrazené barvy.
+        Pokud služba odpovídá rychle, dáváme <b style="color:@(UptimeServer.Availability.GetStatusChartColor(UptimeSSL.Statuses.OK))">zelenou - v pořádku</b>.
+        Pokud odpovídá déle, dáváme <b style="color:@(UptimeServer.Availability.GetStatusChartColor(UptimeSSL.Statuses.Pomalé))">oranžovou - pomalá odpověď.</b>.
+        Pokud neodpoví nebo odpoví za dlouhou dobu, použijeme <b style="color:@(UptimeServer.Availability.GetStatusChartColor(UptimeSSL.Statuses.Nedostupné))">červenou za nedostupnost</b>.
+    </p>
+    @if (ViewData.ContainsKey("DisplayHttpsRating") && (bool)ViewData["DisplayHttpsRating"])
+    {
+        <p>
+            Systém hodnocení HTTPS je jednoduchý: A+ je nejlepší známka, F nejhorší, M znamená špatné jméno serveru v certifikátu, T znamená špatný certifikát, X že zabezpečený přenos není vůbec podporován.
+        </p>
+    }
+    <p>
+        <a href="@Url.Action("JakMerime", "StatniWeby")">Podrobný popis měření a hodnocení</a>.
+    </p>
+</div>

--- a/Web/Views/StatniWeby/_CoVlastneDelamePartial.cshtml
+++ b/Web/Views/StatniWeby/_CoVlastneDelamePartial.cshtml
@@ -1,5 +1,5 @@
 <div class="bs-callout primary">
-    <h4>Hlídání dostupnosti státní webů. Co to vlastně děláme?</h4>
+    <h4>Hlídání dostupnosti státních webů. Co to vlastně děláme?</h4>
     <p>
         Měříme každou minutu, zda důležité weby státu vůbec běží, a pokud ano, tak jak rychle odpovídají. A tomu odpovídají i zobrazené barvy.
         Pokud služba odpovídá rychle, dáváme <b style="color:@(UptimeServer.Availability.GetStatusChartColor(UptimeSSL.Statuses.OK))">zelenou - v pořádku</b>.


### PR DESCRIPTION
V nadpisu boxu o hlídání státních webů je překlep, a když jsem hledal, kde ho opravit, našel jsem ten kus textu rozkopírovaný na třech místech, tak pro něj navrhuji zavést partial.